### PR TITLE
[배포] 중복으로 배포되는 버그

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "deploy": "yarn build && vue-cli-service s3-deploy"
+    "deploy": "vue-cli-service s3-deploy"
   },
   "dependencies": {
     "core-js": "^3.4.4",


### PR DESCRIPTION
- yarn deploy 스크립트에 빌드 프로세스가 끼어있어 배포 중 빌드가 2번 발생하는 오류를 수정합니다.